### PR TITLE
don't ignore bower_ and node_modules

### DIFF
--- a/dotfiles/tilde/gitignore
+++ b/dotfiles/tilde/gitignore
@@ -12,9 +12,3 @@ Thumbs.db
 
 # IDEs stuff
 .idea
-
-# Installed NPM modules
-node_modules
-
-# Installed Bower packages
-bower_components


### PR DESCRIPTION
From `git help ignore`:

> Patterns which a user wants Git to ignore in **all situations** (e.g., backup or temporary files
>            generated by the user's editor of choice) generally go into a file specified by
>            core.excludesFile in the user's ~/.gitconfig.

Having `node_modules/` in `~/.gitignore` results in problems:
1. It's easy to forget to add `node_modules/` to the project `.gitignore` where you want it to be ignored. This will make other developers' `git status` ugly :)
2. It's possible that you could participate in a project that has `node_modules` committed in.
